### PR TITLE
power-8952: Fix array initialization

### DIFF
--- a/power/power-8952.c
+++ b/power/power-8952.c
@@ -67,7 +67,7 @@ static int profile_high_performance_8952[11] = {
     CPU6_MIN_FREQ_TURBO_MAX, CPU7_MIN_FREQ_TURBO_MAX,
 };
 
-static int profile_power_save_8952[5] = {
+static int profile_power_save_8952[] = {
     0x8fe, 0x3dfd, /* 1 big core, 2 little cores*/
     CPUS_ONLINE_MAX_LIMIT_2,
     CPU0_MAX_FREQ_NONTURBO_MAX, CPU1_MAX_FREQ_NONTURBO_MAX,


### PR DESCRIPTION
The array has 7 elements, but is specified as 5.  There's no need
to specify a statically sized array like this, so remove the
size from the declaration.

Change-Id: I4909526738f8a23167f98a888e7e32bd07133df4
