### PR TITLE
power: msm8952: Fix previous_boost_time getting reset

### DIFF
--- a/power/power-8952.c
+++ b/power/power-8952.c
@@ -110,7 +110,8 @@ int  power_hint_override(struct power_module *module, power_hint_t hint,
         void *data)
 {
     int duration, duration_hint;
-    unsigned long long previous_boost_time = 0, cur_boost_time;
+    static unsigned long long previous_boost_time = 0;
+    unsigned long long cur_boost_time;
     struct timeval cur_boost_timeval = {0, 0};
     double elapsed_time;
     int resources_launch_boost[] = {


### PR DESCRIPTION
As previous_boost_time was not static, its value gets resetted to 0
everytime power_hint_override() is called. As a result, the following
statement will always result in elapsed_time == cur_boost_time:

```
elapsed_time = (double)(cur_boost_time - previous_boost_time);
```

This in turn causes the following check to always return false:

```
if (elapsed_time < 250000 && duration <= 750)
```

Change-Id: Idcc22a6f8f10c989ca74a385d3d240c49ef94c2c
