### PR TITLE
power: add support for PowerHAL in Feero

### DIFF
--- a/power/Android.mk
+++ b/power/Android.mk
@@ -49,6 +49,10 @@ ifeq ($(call is-board-platform-in-list, msm8952), true)
 LOCAL_SRC_FILES += power-8952.c
 endif
 
+ifeq ($(call is-board-platform-in-list,msm8937), true)
+LOCAL_SRC_FILES += power-8952.c
+endif
+
 ifeq ($(call is-board-platform-in-list, apq8084), true)
 LOCAL_SRC_FILES += power-8084.c
 endif


### PR DESCRIPTION
powerhal is enabled for Feero

Change-Id: Ice606eb34ec175f17c69d86961889cad96c53a5f
