### PR TITLE
power/8996: Disable sched grouping for flings

### DIFF
--- a/power/power-8996.c
+++ b/power/power-8996.c
@@ -303,7 +303,7 @@ int power_hint_override(__unused struct power_module *module,
         MIN_FREQ_BIG_CORE_0, 0x3E8,
         MIN_FREQ_LITTLE_CORE_0, 0x3E8,
         SCHED_BOOST_ON_V3, 0x1,
-        SCHED_GROUP_ON, 0x1,
+   //   SCHED_GROUP_ON, 0x1,
     };
 
     int resources_interaction_boost[] = {


### PR DESCRIPTION
- The underlying implementation assumes that the perfd client
  is running in-process, but in our architecture we are not.
  This results in system_server being colocated, which is not
  what we want.
- Disable this feature until we move interaction boosts to
  app space.

Change-Id: I0f899c17e0a16b3e3491d7b8314cfdf042628abb
